### PR TITLE
feat: Change model selection to dropdown with Ollama API integration

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -6,9 +6,11 @@
   <style>
     body { font-family: sans-serif; padding: 20px; }
     label { display: block; margin-top: 10px; }
-    input { width: 100%; padding: 5px; margin-top: 5px; box-sizing: border-box; }
+    input, select { width: 100%; padding: 5px; margin-top: 5px; box-sizing: border-box; }
     button { margin-top: 15px; padding: 6px 12px; font-size: 1em; }
     #status { margin-top: 10px; color: #4CAF50; }
+    .loading { color: #666; }
+    .error { color: #f44336; }
   </style>
 </head>
 <body>
@@ -19,7 +21,9 @@
   </label>
   <label>
     モデル名:
-    <input type="text" id="modelInput" placeholder="gemma3:27b-it-qat">
+    <select id="modelSelect">
+      <option value="">モデルを読み込み中...</option>
+    </select>
   </label>
   <button id="saveBtn">保存</button>
   <div id="status"></div>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,20 +1,103 @@
 document.addEventListener('DOMContentLoaded', () => {
   const endpointInput = document.getElementById('endpointInput');
-  const modelInput = document.getElementById('modelInput');
+  const modelSelect = document.getElementById('modelSelect');
   const status = document.getElementById('status');
+  
+  let currentEndpoint = '';
+  let savedModelName = '';
+
   // Load existing settings or use defaults
   chrome.storage.sync.get(
     { ollamaEndpoint: 'http://localhost:11434', modelName: 'gemma3:27b-it-qat' },
     (items) => {
       endpointInput.value = items.ollamaEndpoint;
-      modelInput.value = items.modelName;
+      savedModelName = items.modelName;
+      currentEndpoint = items.ollamaEndpoint;
+      fetchModels(items.ollamaEndpoint);
     }
   );
+
+  // Fetch models when endpoint changes
+  endpointInput.addEventListener('blur', () => {
+    const newEndpoint = endpointInput.value.trim();
+    if (newEndpoint !== currentEndpoint && newEndpoint) {
+      currentEndpoint = newEndpoint;
+      fetchModels(newEndpoint);
+    }
+  });
+
+  // Fetch available models from Ollama API
+  async function fetchModels(endpoint) {
+    if (!endpoint) return;
+    
+    try {
+      modelSelect.innerHTML = '<option value="">モデルを読み込み中...</option>';
+      modelSelect.disabled = true;
+      
+      const response = await fetch(`${endpoint}/api/tags`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      
+      const data = await response.json();
+      modelSelect.innerHTML = '';
+      
+      if (data.models && data.models.length > 0) {
+        data.models.forEach(model => {
+          const option = document.createElement('option');
+          option.value = model.name;
+          option.textContent = model.name;
+          if (model.name === savedModelName) {
+            option.selected = true;
+          }
+          modelSelect.appendChild(option);
+        });
+      } else {
+        modelSelect.innerHTML = '<option value="">モデルが見つかりません</option>';
+      }
+      
+    } catch (error) {
+      console.error('Failed to fetch models:', error);
+      modelSelect.innerHTML = '<option value="">エラー: モデルを取得できませんでした</option>';
+      status.textContent = `モデル取得エラー: ${error.message}`;
+      status.className = 'error';
+      setTimeout(() => { 
+        status.textContent = ''; 
+        status.className = '';
+      }, 3000);
+    } finally {
+      modelSelect.disabled = false;
+    }
+  }
+
   document.getElementById('saveBtn').addEventListener('click', () => {
     const endpoint = endpointInput.value.trim();
-    const modelName = modelInput.value.trim();
+    const modelName = modelSelect.value;
+    
+    if (!endpoint) {
+      status.textContent = 'エンドポイントを入力してください。';
+      status.className = 'error';
+      setTimeout(() => { 
+        status.textContent = ''; 
+        status.className = '';
+      }, 2000);
+      return;
+    }
+    
+    if (!modelName) {
+      status.textContent = 'モデルを選択してください。';
+      status.className = 'error';
+      setTimeout(() => { 
+        status.textContent = ''; 
+        status.className = '';
+      }, 2000);
+      return;
+    }
+    
     chrome.storage.sync.set({ ollamaEndpoint: endpoint, modelName }, () => {
       status.textContent = '設定を保存しました。';
+      status.className = '';
+      savedModelName = modelName;
       setTimeout(() => { status.textContent = ''; }, 2000);
     });
   });


### PR DESCRIPTION
Replace text input with select dropdown for model selection that fetches available models from Ollama's `/api/tags` endpoint.

## Changes
- Replace text input with select dropdown for model selection
- Fetch available models from {endpoint}/api/tags automatically
- Add loading states and error handling with Japanese messages
- Refresh models when endpoint changes
- Auto-select previously saved model when available
- Add validation for empty endpoint/model selection

Fixes #3

Generated with [Claude Code](https://claude.ai/code)